### PR TITLE
Fix the project existence check

### DIFF
--- a/src/leiningen/nevam.clj
+++ b/src/leiningen/nevam.clj
@@ -5,7 +5,7 @@
 (defn ^:no-project-needed nevam
   "Reverse engineer your maven pom.xml files."
   [project & args]
-  (if project
+  (if-not (seq project)
     (println "project.clj file already exists") ;; TODO accept :force
     (let [dir (System/getProperty "user.dir")
           f (io/file (str dir "/pom.xml"))]


### PR DESCRIPTION
muhoo on IRC was asking about an issue with the library where it was thinking there was a project.clj when there actually wasn't. I took a look and the fix was easy. He confirmed it works.

Regarding the fix, I really wanted to swap the if branches so that I didn't have to use if-not, but that would have messed up your comment and I didn't want to remove it.

Cheers!
